### PR TITLE
fix(ci): resolve biome format/lint violations blocking Release gate

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "knowledge-crib": {
       "command": "/Users/vishalchawla/Library/pnpm/crib",
-      "args": [
-        "serve",
-        "${workspaceFolder}"
-      ]
+      "args": ["serve", "${workspaceFolder}"]
     }
   }
 }

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -399,7 +399,9 @@ describe('crib index — token-savings hero output (P1 instant value)', () => {
     mkdirSync(join(heroRepo, 'src'), { recursive: true });
     // a deliberately central function (high in-degree) called from several other files padded with
     // unrelated content, so the raw-file-read cost meaningfully exceeds the one-line query response.
-    const filler = Array.from({ length: 40 }, (_, i) => `export const filler${i} = ${i};`).join('\n');
+    const filler = Array.from({ length: 40 }, (_, i) => `export const filler${i} = ${i};`).join(
+      '\n',
+    );
     writeFileSync(
       join(heroRepo, 'src', 'core.ts'),
       `${filler}\nexport function widgetCore(id: string): string {\n  return id.toUpperCase();\n}\n`,
@@ -412,7 +414,9 @@ describe('crib index — token-savings hero output (P1 instant value)', () => {
     }
     const r = runHero(['index', '.']);
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/≈\d+(\.\d+)?x fewer tokens per discovery query than reading files directly/);
+    expect(r.stdout).toMatch(
+      /≈\d+(\.\d+)?x fewer tokens per discovery query than reading files directly/,
+    );
     expect(r.stdout).toContain('via crib query');
   });
 
@@ -420,7 +424,10 @@ describe('crib index — token-savings hero output (P1 instant value)', () => {
     heroRepo = mkdtempSync(join(tmpdir(), 'crib-cli-hero-tiny-'));
     writeFileSync(join(heroRepo, 'package.json'), JSON.stringify({ name: 'tiny', type: 'module' }));
     mkdirSync(join(heroRepo, 'src'), { recursive: true });
-    writeFileSync(join(heroRepo, 'src', 'a.ts'), 'export function one(): number {\n  return 1;\n}\n');
+    writeFileSync(
+      join(heroRepo, 'src', 'a.ts'),
+      'export function one(): number {\n  return 1;\n}\n',
+    );
     const r = runHero(['index', '.']);
     expect(r.status).toBe(0);
     expect(r.stdout).not.toMatch(/fewer tokens per discovery query/);
@@ -441,7 +448,11 @@ describe('crib update --package (P4 multi-package federation) — CLI dispatch',
         .filter((l) => !/ExperimentalWarning|trace-warnings/.test(l))
         .join('\n')
         .trim();
-    return { status: r.status ?? 1, stdout: stripNoise(r.stdout ?? ''), stderr: stripNoise(r.stderr ?? '') };
+    return {
+      status: r.status ?? 1,
+      stdout: stripNoise(r.stdout ?? ''),
+      stderr: stripNoise(r.stderr ?? ''),
+    };
   };
   const git = (args: string[]): string =>
     execFileSync('git', ['-C', fedRepo, ...args], { encoding: 'utf8' }).trim();
@@ -455,7 +466,10 @@ describe('crib update --package (P4 multi-package federation) — CLI dispatch',
     ] as const) {
       mkdirSync(join(fedRepo, rel, 'src'), { recursive: true });
       writeFileSync(join(fedRepo, rel, 'package.json'), JSON.stringify({ name, version: '0.0.0' }));
-      writeFileSync(join(fedRepo, rel, 'src', 'index.ts'), `export const ${name.replace('-', '_')} = 1;\n`);
+      writeFileSync(
+        join(fedRepo, rel, 'src', 'index.ts'),
+        `export const ${name.replace('-', '_')} = 1;\n`,
+      );
     }
     git(['init', '-q']);
     git(['add', '-A']);
@@ -468,8 +482,14 @@ describe('crib update --package (P4 multi-package federation) — CLI dispatch',
     expect(indexed.status).toBe(0);
     const h1 = git(['rev-parse', 'HEAD']);
 
-    writeFileSync(join(fedRepo, 'packages', 'pkg-a', 'src', 'index.ts'), 'export const pkg_a = 2;\n');
-    writeFileSync(join(fedRepo, 'packages', 'pkg-b', 'src', 'index.ts'), 'export const pkg_b = 2;\n');
+    writeFileSync(
+      join(fedRepo, 'packages', 'pkg-a', 'src', 'index.ts'),
+      'export const pkg_a = 2;\n',
+    );
+    writeFileSync(
+      join(fedRepo, 'packages', 'pkg-b', 'src', 'index.ts'),
+      'export const pkg_b = 2;\n',
+    );
     git(['add', 'packages/pkg-a/src/index.ts', 'packages/pkg-b/src/index.ts']);
     git(['-c', 'user.email=t@t.test', '-c', 'user.name=T', 'commit', '-q', '-m', 'edit both']);
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -146,7 +146,12 @@ function parsePackages(args: string[]): string[] {
 function resolvePackageScope(
   repoRoot: string,
   args: string[],
-): { status: number; packageRoots?: string[]; layout: WorkspaceLayout | null; indexedPackages: string[] } {
+): {
+  status: number;
+  packageRoots?: string[];
+  layout: WorkspaceLayout | null;
+  indexedPackages: string[];
+} {
   const layout = detectWorkspace(repoRoot);
   const tokens = parsePackages(args);
   const allPackages = layout ? layout.packages.map((p) => p.rel) : [];
@@ -155,10 +160,9 @@ function resolvePackageScope(
       process.stderr.write(
         `monorepo detected (${layout.tool}): ${layout.packages.length} package(s)\n`,
       );
-      for (const p of layout.packages)
-        process.stderr.write(`  - ${p.name}  (${p.rel})\n`);
+      for (const p of layout.packages) process.stderr.write(`  - ${p.name}  (${p.rel})\n`);
       process.stderr.write(
-        `scope one with: crib index . --package <name>  |  all: --package all\n`,
+        'scope one with: crib index . --package <name>  |  all: --package all\n',
       );
     }
     return { status: EXIT.OK, packageRoots: undefined, layout, indexedPackages: allPackages };
@@ -168,7 +172,9 @@ function resolvePackageScope(
   for (const token of tokens) {
     const r = resolvePackageArg(repoRoot, token, layout);
     if (r.unknown) {
-      const valid = layout ? layout.packages.map((p) => p.name).join(', ') : '(none — not a monorepo)';
+      const valid = layout
+        ? layout.packages.map((p) => p.name).join(', ')
+        : '(none — not a monorepo)';
       process.stderr.write(`unknown package: ${r.unknown}\navailable: ${valid}\n`);
       return { status: EXIT.BAD_ARGS, layout, indexedPackages: [] };
     }
@@ -418,9 +424,7 @@ async function cmdIndex(args: string[], ctx?: CmdCtx): Promise<number> {
   const index = buildIndex({ repoRoot, cribDir, soul });
   registerIndexed(repoRoot, cribDir, soul);
   const stats = soul.getManifest().stats;
-  const scopeSuffix = scope.packageRoots
-    ? ` [scoped: ${scope.indexedPackages.join(', ')}]`
-    : '';
+  const scopeSuffix = scope.packageRoots ? ` [scoped: ${scope.indexedPackages.join(', ')}]` : '';
   process.stdout.write(
     `indexed ${report.files} files → ${stats.nodes} nodes, ${stats.edges} edges ` +
       `(${report.link.describes} describes, ${report.link.references} references)${scopeSuffix} in ${Date.now() - started}ms\n`,
@@ -999,9 +1003,7 @@ async function cmdReindex(args: string[], ctx?: CmdCtx): Promise<number> {
   index.close();
   registerIndexed(repoRoot, cribDir, soul);
   const stats = soul.getManifest().stats;
-  const scopeSuffix = scope.packageRoots
-    ? ` [scoped: ${scope.indexedPackages.join(', ')}]`
-    : '';
+  const scopeSuffix = scope.packageRoots ? ` [scoped: ${scope.indexedPackages.join(', ')}]` : '';
   process.stdout.write(
     `reindexed ${report.files} files → ${stats.nodes} nodes, ${stats.edges} edges ` +
       `(${report.link.describes} describes, ${report.link.references} references)${scopeSuffix} in ${Date.now() - started}ms\n`,

--- a/packages/parsers/src/php/PhpExtractor.test.ts
+++ b/packages/parsers/src/php/PhpExtractor.test.ts
@@ -62,7 +62,12 @@ describe('PhpExtractor — golden (P3 tree-sitter proof-of-concept gate)', () =>
 
   it('declares capability-honest flags (no resolver ⇒ inheritance:false despite captured bases)', async () => {
     const capabilities = new PhpExtractor().capabilities;
-    expect(capabilities).toEqual({ imports: false, calls: true, inheritance: false, types: 'none' });
+    expect(capabilities).toEqual({
+      imports: false,
+      calls: true,
+      inheritance: false,
+      types: 'none',
+    });
   });
 
   it('emits member-of edges: methods → class/interface, top-level symbols → file', async () => {

--- a/packages/pipeline/src/pipeline.test.ts
+++ b/packages/pipeline/src/pipeline.test.ts
@@ -192,9 +192,16 @@ describe('indexRepo — PHP end-to-end (P3 tree-sitter proof-of-concept, full pi
     mkdirSync(join(repo, 'src', 'legacy'), { recursive: true });
     writeFileSync(
       join(repo, 'src', 'legacy', 'greeter.php'),
-      ['<?php', 'function greet($name) {', '    return shout($name);', '}', 'function shout($name) {', '    return strtoupper($name);', '}', ''].join(
-        '\n',
-      ),
+      [
+        '<?php',
+        'function greet($name) {',
+        '    return shout($name);',
+        '}',
+        'function shout($name) {',
+        '    return strtoupper($name);',
+        '}',
+        '',
+      ].join('\n'),
     );
     const soul = soulFor();
     const report = await indexRepo(soul, repo, { now: '2026-01-01T00:00:00.000Z' });

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -121,7 +121,8 @@ export async function indexRepo(
 
   const discoverOpts: { ignores?: Set<string>; packageRoots?: string[] } = {};
   if (opts.ignores) discoverOpts.ignores = opts.ignores;
-  if (opts.packageRoots && opts.packageRoots.length > 0) discoverOpts.packageRoots = opts.packageRoots;
+  if (opts.packageRoots && opts.packageRoots.length > 0)
+    discoverOpts.packageRoots = opts.packageRoots;
   const files = discoverFiles(root, discoverOpts);
   runStructure(soul, root, files); // Phase 1
   const parse = await runParse(soul, registry, root, files); // Phase 2 + 3b (Markdown extractor)

--- a/packages/pipeline/src/update.test.ts
+++ b/packages/pipeline/src/update.test.ts
@@ -351,7 +351,16 @@ describe('updateRepo — packageRoots (P4 multi-package federation)', () => {
       "import { greet } from './a.js';\nexport function main(): string { return greet() + '!'; }\n",
     );
     git(repo, ['add', 'src/a.ts', 'src/b.ts']);
-    git(repo, ['-c', 'user.email=t@t.test', '-c', 'user.name=T', 'commit', '-q', '-m', 'edit both']);
+    git(repo, [
+      '-c',
+      'user.email=t@t.test',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-q',
+      '-m',
+      'edit both',
+    ]);
 
     const soul = soulFor();
     const result = await updateRepo(soul, repo, {
@@ -390,7 +399,16 @@ describe('updateRepo — packageRoots (P4 multi-package federation)', () => {
 
     writeFileSync(join(repo, 'src', 'a.ts'), "export function greet(): string { return 'yo'; }\n");
     git(repo, ['add', 'src/a.ts']);
-    git(repo, ['-c', 'user.email=t@t.test', '-c', 'user.name=T', 'commit', '-q', '-m', 'edit a only']);
+    git(repo, [
+      '-c',
+      'user.email=t@t.test',
+      '-c',
+      'user.name=T',
+      'commit',
+      '-q',
+      '-m',
+      'edit a only',
+    ]);
     const h2 = git(repo, ['rev-parse', 'HEAD']);
 
     const soul = soulFor();

--- a/packages/pipeline/src/workspace.test.ts
+++ b/packages/pipeline/src/workspace.test.ts
@@ -2,8 +2,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { detectWorkspace, resolvePackageArg } from './workspace.js';
 import { discoverFiles } from './structure.js';
+import { detectWorkspace, resolvePackageArg } from './workspace.js';
 
 let repo: string;
 beforeEach(() => {

--- a/packages/pipeline/src/workspace.ts
+++ b/packages/pipeline/src/workspace.ts
@@ -14,7 +14,7 @@
  * stays unified. Splitting into one soul per package would lose cross-package blast radius — the
  * killer feature — so we scope extraction, not storage.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, join, sep } from 'node:path';
 
 export interface WorkspacePackage {
@@ -112,9 +112,7 @@ function detectNpmWorkspaces(root: string): WorkspaceLayout | null {
   } catch {
     return null;
   }
-  const patterns = Array.isArray(pkg.workspaces)
-    ? pkg.workspaces
-    : pkg.workspaces?.packages;
+  const patterns = Array.isArray(pkg.workspaces) ? pkg.workspaces : pkg.workspaces?.packages;
   const arr = toStringArray(patterns);
   if (arr.length === 0) return null;
   const packages = expandPatterns(root, arr);
@@ -255,7 +253,7 @@ function globDirs(root: string, pattern: string): string[] {
           } catch {
             continue;
           }
-          const childPrefix = prefix === '' ? entry : prefix + '/' + entry;
+          const childPrefix = prefix === '' ? entry : `${prefix}/${entry}`;
           results.push(...walk(abs, idx, childPrefix));
           results.push(...walk(abs, idx + 1, childPrefix));
         }
@@ -275,7 +273,7 @@ function globDirs(root: string, pattern: string): string[] {
           } catch {
             continue;
           }
-          const childPrefix = prefix === '' ? entry : prefix + '/' + entry;
+          const childPrefix = prefix === '' ? entry : `${prefix}/${entry}`;
           results.push(...walk(abs, idx + 1, childPrefix));
         }
       } catch {
@@ -290,7 +288,7 @@ function globDirs(root: string, pattern: string): string[] {
     } catch {
       return [];
     }
-    const childPrefix = prefix === '' ? seg : prefix + '/' + seg;
+    const childPrefix = prefix === '' ? seg : `${prefix}/${seg}`;
     return walk(abs, idx + 1, childPrefix);
   };
   return walk(root, 0, '');
@@ -325,7 +323,8 @@ function toStringArray(v: unknown): string[] {
 
 function stripQuotes(s: string): string {
   let out = s.trim();
-  const isQuote = (ch: string): boolean => ch === '"' || ch === "'" || ch === String.fromCharCode(0x60);
+  const isQuote = (ch: string): boolean =>
+    ch === '"' || ch === "'" || ch === String.fromCharCode(0x60);
   while (out.length > 0 && isQuote(out[0]!)) out = out.slice(1);
   while (out.length > 0 && isQuote(out[out.length - 1]!)) out = out.slice(0, -1);
   return out.trim();

--- a/packages/ui/src/viz.test.ts
+++ b/packages/ui/src/viz.test.ts
@@ -103,10 +103,7 @@ describe('buildVizGraph — importance/tier ranking (declutter)', () => {
     const lonely = sym('src/c.ts', 'C.go', 1);
 
     soul.putNodes([hub, caller1, caller2, lonely]);
-    soul.putEdges([
-      edge(caller1.id, hub.id, 'calls'),
-      edge(caller2.id, hub.id, 'calls'),
-    ]);
+    soul.putEdges([edge(caller1.id, hub.id, 'calls'), edge(caller2.id, hub.id, 'calls')]);
     soul.commit('2026-01-01T00:00:00.000Z');
 
     const graph = buildVizGraph(soul);

--- a/scripts/crib-ab-task.mjs
+++ b/scripts/crib-ab-task.mjs
@@ -20,7 +20,7 @@
  * Run: node scripts/crib-ab-task.mjs   (from an indexed checkout).
  */
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { coldCost, sessionCost, usd } from './lib/pricing.mjs';
 


### PR DESCRIPTION
## What
Fixes pre-existing biome format/lint errors (format, organizeImports, style rules) across the repo.

## Why
Release gate job fails on every PR — including the Dependabot security PR for actions/download-artifact (GHSA-cxww-7g56-2vh6) — due to these unrelated pre-existing violations. This unblocks CI so security PRs can actually go green.

## How tested
- npx biome check . — 0 errors after fix
- Diffs are formatting/style-only (template literals, unused template literal, import order) — no logic changes, confirmed by reading full diff